### PR TITLE
Convert buildr functions to actions

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -4,5 +4,7 @@ export * from './filter-events';
 export * from './let-in-events';
 export * from './map-events';
 export * from './once-event';
+export * from './resolve-events';
+export * from './resolve-events-in-order';
 export * from './share-events';
 export * from './value-events';

--- a/src/actions/resolve-events-in-order.spec.ts
+++ b/src/actions/resolve-events-in-order.spec.ts
@@ -1,9 +1,9 @@
 import { asis, Supply } from '@proc7ts/primitives';
-import { EventEmitter } from './event-emitter';
-import { onAsync } from './on-async';
+import { EventEmitter } from '../senders';
+import { resolveEventsInOrder } from './resolve-events-in-order';
 import Mock = jest.Mock;
 
-describe('onAsync', () => {
+describe('resolveEventsInOrder', () => {
 
   let origin: EventEmitter<[(string | Promise<string>)]>;
   let receiver: Mock<void, string[]>;
@@ -25,7 +25,7 @@ describe('onAsync', () => {
         received.push(Promise.resolve(event));
       }
     });
-    supply = onAsync(origin)(receiver).whenOff(reason => {
+    supply = origin.on.do(resolveEventsInOrder)(receiver).whenOff(reason => {
 
       const resolver = resolvers.shift();
 

--- a/src/actions/resolve-events.spec.ts
+++ b/src/actions/resolve-events.spec.ts
@@ -1,9 +1,9 @@
 import { asis, Supply } from '@proc7ts/primitives';
-import { EventEmitter } from './event-emitter';
-import { onAnyAsync } from './on-any-async';
+import { EventEmitter } from '../senders';
+import { resolveEvents } from './resolve-events';
 import Mock = jest.Mock;
 
-describe('onAnyAsync', () => {
+describe('resolveEvents', () => {
 
   let origin: EventEmitter<[(string | Promise<string>)]>;
   let receiver: Mock<void, [string, number]>;
@@ -25,7 +25,7 @@ describe('onAnyAsync', () => {
         received.push(Promise.resolve(event));
       }
     });
-    supply = onAnyAsync(origin)(receiver).whenOff(reason => {
+    supply = origin.on.do(resolveEvents)(receiver).whenOff(reason => {
 
       const resolver = resolvers.shift();
 

--- a/src/actions/resolve-events.ts
+++ b/src/actions/resolve-events.ts
@@ -2,12 +2,12 @@
  * @packageDocumentation
  * @module @proc7ts/fun-events
  */
-import { EventSender, OnEvent__symbol, sendEventsTo } from '../base';
+import { sendEventsTo } from '../base';
 import { OnEvent, onEventBy } from '../on-event';
 
 /**
- * Builds an {@link OnEvent} sender of any of asynchronously resolved events originated from the given sender of
- * unresolved events.
+ * Creates an {@link OnEvent} sender of asynchronously resolved events originated from the given sender of event
+ * promises.
  *
  * Receives events or their promises from the given event sender, and sends them once they are resolved. The original
  * order of events is not preserved. Instead each resolved event is sent along with its index in original order.
@@ -17,11 +17,11 @@ import { OnEvent, onEventBy } from '../on-event';
  *
  * @category Core
  * @typeParam T - A type of values the promises resolve to.
- * @param from - Unresolved events sender containing either events or their promises.
+ * @param from - A sender of events or promise-like instances resolved to ones.
  *
  * @returns New `OnEvent` sender of resolved events and their indices in original order starting from `1`.
  */
-export function onAnyAsync<T>(from: EventSender<[PromiseLike<T> | T]>): OnEvent<[T, number]> {
+export function resolveEvents<T>(from: OnEvent<[PromiseLike<T> | T]>): OnEvent<[T, number]> {
   return onEventBy(receiver => {
 
     const { supply } = receiver;
@@ -29,7 +29,7 @@ export function onAnyAsync<T>(from: EventSender<[PromiseLike<T> | T]>): OnEvent<
 
     let lastIndex = 0;
 
-    from[OnEvent__symbol]()({
+    from({
       supply,
       receive(_ctx, promise) {
 

--- a/src/senders/index.ts
+++ b/src/senders/index.ts
@@ -1,7 +1,5 @@
 export * from './event-emitter';
 export * from './on-any';
-export * from './on-any-async';
-export * from './on-async';
 export * from './on-never';
 export * from './on-promise';
 export * from './on-supplied';

--- a/src/senders/on-any.ts
+++ b/src/senders/on-any.ts
@@ -3,7 +3,7 @@
  * @module @proc7ts/fun-events
  */
 import { Supply } from '@proc7ts/primitives';
-import { shareEvents } from '../actions/share-events';
+import { shareEvents } from '../actions';
 import { EventReceiver, EventSupplier } from '../base';
 import { OnEvent, onEventBy } from '../on-event';
 import { onNever } from './on-never';


### PR DESCRIPTION
- Replace `onAsync()` builder with `resolveEventsInOrder` action
- Replace `onAnyAsync()` builder with `resolveEvents` action
