### PR TITLE
Wider supplier checks

### DIFF
--- a/src/base/event-keeper.spec.ts
+++ b/src/base/event-keeper.spec.ts
@@ -1,0 +1,38 @@
+import { valueProvider } from '@proc7ts/primitives';
+import { afterNever } from '../keepers';
+import { onNever } from '../senders';
+import { AfterEvent__symbol, isEventKeeper } from './event-keeper';
+import { OnEvent__symbol } from './event-sender';
+
+describe('isEventKeeper', () => {
+  it('returns `false` for `null`', () => {
+    expect(isEventKeeper(null)).toBe(false);
+  });
+  it('returns `false` for numbers', () => {
+    expect(isEventKeeper(12)).toBe(false);
+  });
+  it('returns `false` for strings', () => {
+    expect(isEventKeeper('123')).toBe(false);
+  });
+  it('returns `false` for object', () => {
+    expect(isEventKeeper({ foo: 'bar' })).toBe(false);
+  });
+  it('returns `false` for function', () => {
+    expect(isEventKeeper(valueProvider(123))).toBe(false);
+  });
+  it('returns `false` if `[AfterEvent__symbol]` property is not a method', () => {
+    expect(isEventKeeper({ [AfterEvent__symbol]: true })).toBe(false);
+  });
+  it('returns `true` for `AfterEvent` instance', () => {
+    expect(isEventKeeper(afterNever)).toBe(true);
+  });
+  it('returns `false` for `OnEvent` instance', () => {
+    expect(isEventKeeper(onNever)).toBe(false);
+  });
+  it('returns `true` for object with `[AfterEvent__symbol]` method', () => {
+    expect(isEventKeeper({ [AfterEvent__symbol]: afterNever })).toBe(true);
+  });
+  it('returns `false` for object with `[OnEvent__symbol]` method', () => {
+    expect(isEventKeeper({ [OnEvent__symbol]: onNever })).toBe(false);
+  });
+});

--- a/src/base/event-keeper.ts
+++ b/src/base/event-keeper.ts
@@ -52,8 +52,10 @@ export namespace EventKeeper {
  * @typeParam TEvent - An event type. This is a list of event receiver parameter types.
  * @param value - An object to check.
  *
- * @returns `true` if `value` contains an {@link AfterEvent__symbol} property, or `false` otherwise.
+ * @returns `true` if `value` contains an {@link AfterEvent__symbol} method, or `false` otherwise.
  */
-export function isEventKeeper<TEvent extends any[]>(value: object): value is EventKeeper<TEvent> {
-  return AfterEvent__symbol in value;
+export function isEventKeeper<TEvent extends any[]>(value: unknown): value is EventKeeper<TEvent> {
+  return !!value
+      && (typeof value === 'object' || typeof value === 'function')
+      && typeof (value as Partial<EventKeeper<TEvent>>)[AfterEvent__symbol] === 'function';
 }

--- a/src/base/event-sender.spec.ts
+++ b/src/base/event-sender.spec.ts
@@ -1,0 +1,30 @@
+import { valueProvider } from '@proc7ts/primitives';
+import { onNever } from '../senders';
+import { isEventSender, OnEvent__symbol } from './event-sender';
+
+describe('isEventSender', () => {
+  it('returns `false` for `null`', () => {
+    expect(isEventSender(null)).toBe(false);
+  });
+  it('returns `false` for numbers', () => {
+    expect(isEventSender(12)).toBe(false);
+  });
+  it('returns `false` for strings', () => {
+    expect(isEventSender('123')).toBe(false);
+  });
+  it('returns `false` for object', () => {
+    expect(isEventSender({ foo: 'bar' })).toBe(false);
+  });
+  it('returns `false` for function', () => {
+    expect(isEventSender(valueProvider(123))).toBe(false);
+  });
+  it('returns `false` if `[OnEvent__symbol]` property is not a method', () => {
+    expect(isEventSender({ [OnEvent__symbol]: true })).toBe(false);
+  });
+  it('returns `true` for `OnEvent` instance', () => {
+    expect(isEventSender(onNever)).toBe(true);
+  });
+  it('returns `true` for object with `[OnEvent__symbol]` method', () => {
+    expect(isEventSender({ [OnEvent__symbol]: onNever })).toBe(true);
+  });
+});

--- a/src/base/event-sender.ts
+++ b/src/base/event-sender.ts
@@ -56,5 +56,5 @@ export namespace EventSender {
 export function isEventSender<TEvent extends any[]>(value: unknown): value is EventSender<TEvent> {
   return !!value
       && (typeof value === 'object' || typeof value === 'function')
-      && typeof (value as EventSender<TEvent>)[OnEvent__symbol] === 'function';
+      && typeof (value as Partial<EventSender<TEvent>>)[OnEvent__symbol] === 'function';
 }

--- a/src/base/event-sender.ts
+++ b/src/base/event-sender.ts
@@ -51,8 +51,10 @@ export namespace EventSender {
  * @typeParam TEvent - An event type. This is a list of event receiver parameter types.
  * @param value - An object to check.
  *
- * @returns `true` if `value` contains {@link OnEvent__symbol} property, or `false` otherwise.
+ * @returns `true` if `value` contains an {@link OnEvent__symbol} method, or `false` otherwise.
  */
-export function isEventSender<TEvent extends any[]>(value: object): value is EventSender<TEvent> {
-  return OnEvent__symbol in value;
+export function isEventSender<TEvent extends any[]>(value: unknown): value is EventSender<TEvent> {
+  return !!value
+      && (typeof value === 'object' || typeof value === 'function')
+      && typeof (value as EventSender<TEvent>)[OnEvent__symbol] === 'function';
 }


### PR DESCRIPTION
- `isEventSender` can be applied to any value
- `isEventKeeper` can be applied to any value
