### PR TITLE
Event deduplication

### DIFF
--- a/src/processors/deduplicate-after.spec.ts
+++ b/src/processors/deduplicate-after.spec.ts
@@ -1,0 +1,71 @@
+import { asis, Supply } from '@proc7ts/primitives';
+import { AfterEvent } from '../after-event';
+import { afterSent } from '../keepers';
+import { EventEmitter } from '../senders';
+import { deduplicateAfter } from './deduplicate-after';
+
+describe('deduplicateAfter', () => {
+
+  let source: EventEmitter<[string, string?]>;
+  let dedup: AfterEvent<[string?]>;
+  let receiver: jest.Mock<void, [string?]>;
+  let supply: Supply;
+
+  beforeEach(() => {
+    source = new EventEmitter();
+    dedup = afterSent<[string?, string?]>(
+        source,
+        () => [],
+    ).do(
+        deduplicateAfter(),
+    );
+    supply = dedup(receiver = jest.fn());
+  });
+
+  it('reports the initial event', async () => {
+    expect(receiver).toHaveBeenCalledWith();
+    expect(receiver).toHaveBeenCalledTimes(1);
+    expect(await dedup).toBeUndefined();
+  });
+  it('reports an update', async () => {
+    source.send('update');
+    expect(receiver).toHaveBeenLastCalledWith('update');
+    expect(receiver).toHaveBeenCalledTimes(2);
+    expect(await dedup).toBe('update');
+  });
+  it('does not report a duplicate', () => {
+    source.send('update');
+    source.send('update');
+    expect(receiver).toHaveBeenLastCalledWith('update');
+    expect(receiver).toHaveBeenCalledTimes(2);
+  });
+  it('reports multiple updates', () => {
+    source.send('update', '1');
+    source.send('update', '2');
+    source.send('update', '2');
+    expect(receiver).toHaveBeenCalledWith('update', '1');
+    expect(receiver).toHaveBeenLastCalledWith('update', '2');
+    expect(receiver).toHaveBeenCalledTimes(3);
+  });
+  it('reports updates after cutting off', async () => {
+    source.send('update');
+    supply.off();
+
+    expect(await dedup).toBeUndefined();
+
+    const receiver2 = jest.fn();
+
+    dedup(receiver2);
+    expect(receiver2).toHaveBeenCalledWith();
+
+    source.send('update2');
+    expect(receiver2).toHaveBeenLastCalledWith('update2');
+    expect(receiver2).toHaveBeenCalledTimes(2);
+
+    expect(receiver).not.toHaveBeenCalledWith('update2');
+  });
+  it('is cut off when the source cut off', async () => {
+    source.supply.off('reason');
+    expect(await supply.whenDone().catch(asis)).toBe('reason');
+  });
+});

--- a/src/processors/deduplicate-after.ts
+++ b/src/processors/deduplicate-after.ts
@@ -1,0 +1,45 @@
+import { AfterEvent, afterEventBy } from '../after-event';
+
+/**
+ * Creates an event processor that ensures the same event incoming from `{@link AfterEvent} keeper are not reported
+ * twice.
+ *
+ * The outgoing events supply is cut off once the incoming events supply do.
+ *
+ * @category Event Processing
+ * @typeParam TEvent - An event type.
+ * @param isDuplicate - A function that checks whether the next incoming event is a duplicate of a previously reported
+ * one. Accepts a prior and next event tuples as parameters, and returns a truthy value if they are duplicates.
+ * By default, treats event tuples as duplicates if they have the same number of elements, and each element is
+ * strictly equals to corresponding one.
+ *
+ * @returns Deduplicating processor of events incoming from {@link @AfterEvent} keeper.
+ */
+export function deduplicateAfter<TEvent extends any[]>(
+    isDuplicate: (this: void, prior: TEvent, next: TEvent) => boolean = deduplicateAfter$isDuplicate,
+): (this: void, input: AfterEvent<TEvent>) => AfterEvent<TEvent> {
+  return input => {
+
+    let prior: TEvent | null = null;
+
+    return afterEventBy(
+        receiver => {
+          input({
+            supply: receiver.supply,
+            receive(ctx, ...next) {
+              if (!prior || !isDuplicate(prior, next)) {
+                prior = next;
+                receiver.receive(ctx, ...next);
+              }
+            },
+          });
+        },
+        undefined,
+        _ => prior = null,
+    );
+  };
+}
+
+function deduplicateAfter$isDuplicate<TEvent extends any[]>(prior: TEvent, next: TEvent): boolean {
+  return prior.length === next.length && prior.every((e, i) => e === next[i]);
+}

--- a/src/processors/deduplicate-after.ts
+++ b/src/processors/deduplicate-after.ts
@@ -1,4 +1,5 @@
 import { AfterEvent, afterEventBy } from '../after-event';
+import { shareAfter } from './share-after';
 
 /**
  * Creates an event processor that ensures the same event incoming from `{@link AfterEvent} keeper are not reported
@@ -16,6 +17,30 @@ import { AfterEvent, afterEventBy } from '../after-event';
  * @returns Deduplicating processor of events incoming from {@link @AfterEvent} keeper.
  */
 export function deduplicateAfter<TEvent extends any[]>(
+    isDuplicate?: (this: void, prior: TEvent, next: TEvent) => boolean,
+): (this: void, input: AfterEvent<TEvent>) => AfterEvent<TEvent> {
+
+  const processor = deduplicateAfter_(isDuplicate);
+
+  return input => shareAfter(processor(input));
+}
+
+/**
+ * Creates an event processor that ensures the same event incoming from `{@link AfterEvent} keeper are not reported
+ * twice, and does not share the outgoing events supply.
+ *
+ * The outgoing events supply is cut off once the incoming events supply do.
+ *
+ * @category Event Processing
+ * @typeParam TEvent - An event type.
+ * @param isDuplicate - A function that checks whether the next incoming event is a duplicate of a previously reported
+ * one. Accepts a prior and next event tuples as parameters, and returns a truthy value if they are duplicates.
+ * By default, treats event tuples as duplicates if they have the same number of elements, and each element is
+ * strictly equals to corresponding one.
+ *
+ * @returns Deduplicating processor of events incoming from {@link @AfterEvent} keeper.
+ */
+export function deduplicateAfter_<TEvent extends any[]>(// eslint-disable-line @typescript-eslint/naming-convention
     isDuplicate: (this: void, prior: TEvent, next: TEvent) => boolean = deduplicateAfter$isDuplicate,
 ): (this: void, input: AfterEvent<TEvent>) => AfterEvent<TEvent> {
   return input => {

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -1,4 +1,5 @@
 export * from './consume-events';
+export * from './deduplicate-after';
 export * from './dig-after';
 export * from './dig-on';
 export * from './filter-on';


### PR DESCRIPTION
- `afterEventBy()` accepts a cleanup callback as third parameter.
  It is called when all supplies cut off.
- Add `deduplicateAfter()`: Deduplicating event processor.
