### PR TITLE
Cut off instead of throw

### DIFF
--- a/src/after-event.spec.ts
+++ b/src/after-event.spec.ts
@@ -1,4 +1,4 @@
-import { neverSupply, noop } from '@proc7ts/primitives';
+import { asis, neverSupply, noop } from '@proc7ts/primitives';
 import { AfterEvent, afterEventBy } from './after-event';
 import { AfterEvent__symbol, EventNotifier, EventReceiver, OnEvent__symbol } from './base';
 import Mock = jest.Mock;
@@ -91,5 +91,14 @@ describe('afterEventBy', () => {
 
     expect(mockReceiver).toHaveBeenCalledWith('fallback');
     expect(recurrentReceiver).toHaveBeenCalledWith('recurrent');
+  });
+  it('cuts off event supply on receiver registration failure', async () => {
+
+    const error = new Error('!!!');
+    const onEvent = afterEventBy(() => {
+      throw error;
+    });
+
+    expect(await onEvent(noop).whenDone().catch(asis)).toBe(error);
   });
 });

--- a/src/base/event-receiver.ts
+++ b/src/base/event-receiver.ts
@@ -126,10 +126,7 @@ export namespace EventReceiver {
  */
 export function eventReceiver<TEvent extends any[]>(receiver: EventReceiver<TEvent>): EventReceiver.Generic<TEvent> {
 
-  let generic: {
-    readonly supply: Supply;
-    receive: (context: EventReceiver.Context<TEvent>, ...event: TEvent) => void;
-  };
+  let generic: EventReceiver.Generic<TEvent>;
 
   if (typeof receiver === 'function') {
     generic = {
@@ -139,10 +136,13 @@ export function eventReceiver<TEvent extends any[]>(receiver: EventReceiver<TEve
       },
     };
   } else {
+
+    const { supply = new Supply() } = receiver;
+
     generic = {
-      supply: receiver.supply || new Supply(),
+      supply,
       receive(context, ...event) {
-        if (!this.supply.isOff) {
+        if (!supply.isOff) {
           // Supply cut off callback may be called before the receiver disabled.
           // Such callback may send an event that should not be received.
           receiver.receive(context, ...event);

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -3,4 +3,5 @@ export * from './event-notifier';
 export * from './event-receiver';
 export * from './event-sender';
 export * from './event-supplier';
+export * from './no-events-error';
 export * from './send-events-to';

--- a/src/base/no-events-error.ts
+++ b/src/base/no-events-error.ts
@@ -1,0 +1,21 @@
+/**
+ * An error indicating a failure to receive an expected event.
+ *
+ * This happens e.g. when receiver registered in {@link EventKeeper event keeper}, but the latter has no events to send.
+ * This may happen when no fallback passed to {@link afterEventBy} function, while the given supplier did not send
+ * any events.
+ *
+ * @category Core
+ */
+export class NoEventsError extends TypeError {
+
+  /**
+   * Constructs an error.
+   *
+   * @param message - Error message.
+   */
+  constructor(message = 'No events to send') {
+    super(message);
+  }
+
+}

--- a/src/impl/after-event.no-fallback.ts
+++ b/src/impl/after-event.no-fallback.ts
@@ -1,6 +1,8 @@
+import { NoEventsError } from '../base';
+
 /**
  * @internal
  */
 export function AfterEvent$noFallback(): never {
-  throw new Error('No events to send');
+  throw new NoEventsError();
 }

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -1,5 +1,5 @@
 export * from './after-event.no-fallback';
-export * from './event-dig';
+export * from './dig-events';
 export * from './on-event.do';
 export * from './on-event.supplier';
 export * from './on-event.then';

--- a/src/impl/share-events.ts
+++ b/src/impl/share-events.ts
@@ -9,47 +9,114 @@ export function shareEvents<TEvent extends any[]>(
     supplier: OnEvent<TEvent>,
 ): (receiver: EventReceiver.Generic<TEvent>) => void {
 
-  const shared = new EventNotifier<TEvent>();
-  let sharedSupply: Supply;
-  let initialEvents: TEvent[] | undefined;
+  const sharer = new EventSharer<TEvent>(supplier);
 
-  return (receiver: EventReceiver.Generic<TEvent>): void => {
-    if (!shared.size) {
-      initialEvents = [];
-      sharedSupply = new Supply(() => initialEvents = undefined);
+  return sharer.on.bind(sharer);
+}
 
-      supplier({
-        supply: sharedSupply,
-        receive(_ctx, ...event) {
-          if (initialEvents) {
-            if (shared.size) {
-              // More events received
-              // Stop sending initial ones
-              initialEvents = undefined;
-            } else {
-              // Record events received during first receiver registration
-              // to send them to all receivers until more event received
-              initialEvents.push(event);
-            }
+class EventSharer<TEvent extends any[]> extends EventNotifier<TEvent> {
+
+  private _on: SharedEventDispatcher<TEvent>;
+
+  constructor(readonly supplier: OnEvent<TEvent>) {
+    super();
+    this._on = this._onInit();
+  }
+
+  on(receiver: EventReceiver.Generic<TEvent>): Supply {
+    this._on.on(receiver);
+    return receiver.supply;
+  }
+
+  /**
+   * Initial dispatcher applied when there are no receivers.
+   */
+  private _onInit(): SharedEventDispatcher<TEvent> {
+    return {
+      on: receiver => {
+
+        const initialEvents: TEvent[] = [];
+        const sharedSupply = new Supply(() => this._on = this._onInit());
+        const onFirst = this._on = this._onFirst(sharedSupply, initialEvents);
+
+        try {
+          onFirst.on(receiver);
+          this.supplier({
+            supply: sharedSupply,
+            receive: (_ctx, ...event) => this._on.dispatch(...event),
+          });
+        } finally {
+          if (this._on === onFirst) {
+            this._on = this._onNext(sharedSupply, initialEvents);
           }
-          shared.send(...event);
-        },
-      });
-    }
+        }
+      },
+      dispatch: null!, // Initial dispatcher never dispatches events
+    };
+  }
 
-    receiver.supply.needs(sharedSupply);
-    shared.on(receiver).whenOff((reason?: any) => {
-      if (!shared.size) {
+  /**
+   * A dispatcher applied while the first receiver is still registering, but not registered yet.
+   *
+   * Records emitted events to dispatch them to all receivers.
+   */
+  private _onFirst(sharedSupply: Supply, initialEvents: TEvent[]): SharedEventDispatcher<TEvent> {
+    return {
+      on: receiver => this._addReceiver(receiver, sharedSupply, initialEvents),
+      dispatch: (...event) => {
+        // Record initial event.
+        initialEvents.push(event);
+        this.send(...event);
+      },
+    };
+  }
+
+  /**
+   * A dispatcher applied after the first receiver registered.
+   *
+   * Dispatches initial events to new receivers until new event received.
+   */
+  private _onNext(sharedSupply: Supply, initialEvents: TEvent[]): SharedEventDispatcher<TEvent> {
+    return {
+      on: receiver => this._addReceiver(receiver, sharedSupply, initialEvents),
+      dispatch: (...event) => {
+        // An event received after initial ones.
+        // Stop dispatching initial events.
+        initialEvents.length = 0;
+        this.send(...event);
+      },
+    };
+  }
+
+  private _addReceiver(
+      receiver: EventReceiver.Generic<TEvent>,
+      sharedSupply: Supply,
+      initialEvents: TEvent[],
+  ): void {
+    sharedSupply.cuts(receiver);
+
+    super.on(receiver).whenOff(reason => {
+      if (!this.size) {
         sharedSupply.off(reason);
       }
     });
 
-    if (initialEvents) {
-      // Send initial events to just registered receiver
+    if (initialEvents.length) {
+      // Dispatch initial events.
 
       const dispatch = sendEventsTo(receiver);
 
       initialEvents.forEach(event => dispatch(...event));
     }
-  };
+  }
+
 }
+
+interface SharedEventDispatcher<TEvent extends any[]> {
+
+  on(this: void, receiver: EventReceiver.Generic<TEvent>): void;
+
+  dispatch(...event: TEvent): void;
+
+}
+

--- a/src/keepers/after-supplied.spec.ts
+++ b/src/keepers/after-supplied.spec.ts
@@ -1,6 +1,6 @@
-import { noop, Supply } from '@proc7ts/primitives';
+import { asis, noop, Supply } from '@proc7ts/primitives';
 import { AfterEvent } from '../after-event';
-import { AfterEvent__symbol, EventReceiver } from '../base';
+import { AfterEvent__symbol, EventReceiver, NoEventsError } from '../base';
 import { onceOn } from '../processors';
 import { EventEmitter } from '../senders';
 import { trackValue, ValueTracker } from '../value';
@@ -95,11 +95,8 @@ describe('afterSupplied', () => {
       afterEvent = afterSupplied(sender);
     });
 
-    it('throws an exception upon receiver registration', () => {
-      expect(() => afterEvent(noop)).toThrow('No events to send');
-    });
-    it('throws an exception when requesting the last event', () => {
-      expect(() => afterEvent.do(onceOn)(noop)).toThrow('No events to send');
+    it('cuts off event supply upon receiver registration', async () => {
+      expect(await afterEvent(noop).whenDone().catch(asis)).toBeInstanceOf(NoEventsError);
     });
   });
 });

--- a/src/on-event.spec.ts
+++ b/src/on-event.spec.ts
@@ -1,4 +1,4 @@
-import { asis, neverSupply, noop } from '@proc7ts/primitives';
+import { asis, noop } from '@proc7ts/primitives';
 import { EventNotifier, EventReceiver, OnEvent__symbol } from './base';
 import { OnEvent, onEventBy } from './on-event';
 import Mock = jest.Mock;
@@ -7,7 +7,7 @@ describe('OnEvent', () => {
   describe('[OnEvent__symbol]', () => {
     it('refers to itself', () => {
 
-      const onEvent = onEventBy(neverSupply);
+      const onEvent = onEventBy(({ supply }) => supply.off());
 
       expect(onEvent[OnEvent__symbol]()).toBe(onEvent);
     });
@@ -85,4 +85,18 @@ describe('OnEvent', () => {
       }).catch(asis)).toBe(error);
     });
   });
+});
+
+describe('onEventBy', () => {
+
+  it('cuts off event supply on receiver registration failure', async () => {
+
+    const error = new Error('!!!');
+    const onEvent = onEventBy(() => {
+      throw error;
+    });
+
+    expect(await onEvent(noop).whenDone().catch(asis)).toBe(error);
+  });
+
 });

--- a/src/on-event.ts
+++ b/src/on-event.ts
@@ -325,7 +325,11 @@ export function onEventBy<TEvent extends any[]>(
     const { supply } = generic;
 
     if (!supply.isOff) {
-      register(generic);
+      try {
+        register(generic);
+      } catch (error) {
+        supply.off(error);
+      }
     }
 
     return supply;

--- a/src/processors/dig-after.ts
+++ b/src/processors/dig-after.ts
@@ -4,7 +4,7 @@
  */
 import { AfterEvent, afterEventBy } from '../after-event';
 import { EventKeeper } from '../base';
-import { eventDig } from '../impl';
+import { digEvents } from '../impl';
 import { afterSupplied } from '../keepers';
 import { shareAfter } from './share-after';
 
@@ -61,5 +61,5 @@ export function digAfter_<// eslint-disable-line @typescript-eslint/naming-conve
     return extracted && afterSupplied(extracted);
   };
 
-  return input => afterEventBy(eventDig(input, extractKeeper));
+  return input => afterEventBy(digEvents(input, extractKeeper));
 }

--- a/src/processors/dig-on.spec.ts
+++ b/src/processors/dig-on.spec.ts
@@ -80,7 +80,7 @@ describe('digOn', () => {
     expect(extract).not.toHaveBeenCalled();
     expect(sender.size).toBe(0);
   });
-  it('does not cut off supply when nested events supply cut off', () => {
+  it('cuts off supply when nested events supply cut off', () => {
 
     const whenOff = jest.fn();
 
@@ -93,13 +93,13 @@ describe('digOn', () => {
     nested1.supply.off(reason);
     nested1.send('value2');
 
-    expect(whenOff).not.toHaveBeenCalledWith(reason);
+    expect(whenOff).toHaveBeenCalledWith(reason);
 
     sender.send(nested2);
     nested2.send('value3');
 
     expect(receiver).toHaveBeenCalledWith('value1');
     expect(receiver).not.toHaveBeenCalledWith('value2');
-    expect(receiver).toHaveBeenCalledWith('value3');
+    expect(receiver).not.toHaveBeenCalledWith('value3');
   });
 });

--- a/src/processors/dig-on.ts
+++ b/src/processors/dig-on.ts
@@ -3,7 +3,7 @@
  * @module @proc7ts/fun-events
  */
 import { EventSupplier } from '../base';
-import { eventDig } from '../impl';
+import { digEvents } from '../impl';
 import { OnEvent, onEventBy } from '../on-event';
 import { onSupplied } from '../senders';
 import { shareOn } from './share-on';
@@ -61,5 +61,5 @@ export function digOn_<// eslint-disable-line @typescript-eslint/naming-conventi
     return extracted && onSupplied(extracted);
   };
 
-  return input => onEventBy(eventDig(input, extractSender));
+  return input => onEventBy(digEvents(input, extractSender));
 }

--- a/src/processors/share-after.spec.ts
+++ b/src/processors/share-after.spec.ts
@@ -1,3 +1,4 @@
+import { asis } from '@proc7ts/primitives';
 import { AfterEvent, afterEventBy } from '../after-event';
 import { EventNotifier, EventReceiver } from '../base';
 import { onceOn } from './once-on';
@@ -47,5 +48,12 @@ describe('shareAfter', () => {
     emitter.send('a', 'b');
     expect(mockReceiver).toHaveBeenCalledWith('a', 'b');
     expect(mockReceiver2).toHaveBeenCalledWith('a', 'b');
+  });
+  it('handles immediate source supply cut off', async () => {
+    mockRegister.mockImplementation(({ supply }) => supply.off('reason'));
+
+    const shared = afterEvent.do(shareAfter);
+
+    expect(await shared(mockReceiver).whenDone().catch(asis)).toBe('reason');
   });
 });

--- a/src/processors/share-on.spec.ts
+++ b/src/processors/share-on.spec.ts
@@ -1,3 +1,4 @@
+import { asis } from '@proc7ts/primitives';
 import { AfterEvent, afterEventBy } from '../after-event';
 import { EventNotifier, EventReceiver } from '../base';
 import { OnEvent, onEventBy } from '../on-event';
@@ -174,6 +175,13 @@ describe('shareOn', () => {
       emitter.send('a', 'b');
       expect(mockReceiver).toHaveBeenCalledWith('a', 'b');
       expect(mockReceiver2).toHaveBeenCalledWith('a', 'b');
+    });
+    it('handles immediate source supply cut off', async () => {
+      mockRegister.mockImplementation(({ supply }) => supply.off('reason'));
+
+      const shared = afterEvent.do(shareOn);
+
+      expect(await shared(mockReceiver).whenDone().catch(asis)).toBe('reason');
     });
   });
 });


### PR DESCRIPTION
- Improve event sharing
- Do not throw on event receiver registration failure
- `digOn/After` - cut off events supply if nested supply cut off
